### PR TITLE
Refactor network requests to use fetch and remove unused imports

### DIFF
--- a/src/encryption-helper.js
+++ b/src/encryption-helper.js
@@ -1,4 +1,3 @@
-import crypto from 'crypto';
 import ece from 'http_ece';
 
 export function encrypt(userPublicKey, userAuth, payload, contentEncoding) {

--- a/src/vapid-helper.js
+++ b/src/vapid-helper.js
@@ -1,4 +1,3 @@
-import crypto from 'crypto';
 import asn1 from 'asn1.js';
 import { SignJWT } from 'jose';
 import { URL } from 'url';


### PR DESCRIPTION
Replace `https.request` with `fetch` for network requests and eliminate unused crypto imports to streamline the codebase.